### PR TITLE
ci: finalize the test fixtures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-20.04, windows-latest]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,15 +17,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: '3.10'
     - uses: pre-commit/action@v2.0.0
 
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
-        os: [ubuntu-20.04, windows-latest]
+        python-version: [3.7, 3.8, 3.9, '3.10']
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: '3.10'
 
     - name: Installation (deps and package)
       run: |
@@ -85,7 +85,7 @@ jobs:
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: install flit
       run: |
         pip install flit~=3.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
         pytest --cov=mdformat_admon --cov-report=xml --cov-report=term-missing
 
     - name: Upload to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
+      if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.7
       uses: codecov/codecov-action@v1
       with:
         name: pytests-py3.7

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An [mdformat](https://github.com/executablebooks/mdformat) plugin for admonition
 
 ## Development
 
-This package utilises [flit](https://flit.readthedocs.io) as the build engine, and [tox](https://tox.readthedocs.io) for test automation.
+This package utilizes [flit](https://flit.readthedocs.io) as the build engine, and [tox](https://tox.readthedocs.io) for test automation.
 
 To install these development dependencies:
 

--- a/mdformat_admon/plugin.py
+++ b/mdformat_admon/plugin.py
@@ -26,19 +26,22 @@ def _render_admon(node: RenderTreeNode, context: RenderContext) -> str:
     - https://github.com/executablebooks/mdformat-footnote/blob/80852fc20cfba7fd0330b9ac7a1a4df983542942/mdformat_footnote/plugin.py
 
     """
-    separator = "\n\n"  # TODO: Is this configurable?
-    indent = " " * 4  # FIXME: Is this configurable?
+    prefix = node.markup.split(" ")[0]
     title = node.info.strip()
-    title_line = f"!!! {title}"
+    title_line = f"{prefix} {title}"
+    # The indent is either 3 or 4 based on the length of the prefix
+    #   Ex: '!!!', '...', '..', '???', '???+', etc.
+    indent = " " * (min(len(prefix), 3) + 1)
     with context.indented(len(indent)):  # Modifies context.env['indent_width']
         elements = [child.render(context) for child in node.children]
+    # See: https://mdformat.readthedocs.io/en/stable/users/configuration_file.html
+    separator = "\n\n"  # FIXME: Use mdformat's 'end_of_line'
     content = textwrap.indent(separator.join(e for e in elements if e), indent)
-    if content:
-        return title_line + "\n" + content
-    return title_line
+    return title_line + "\n" + content if content else title_line
 
 
 def _render_admon_title(node: RenderTreeNode, context: RenderContext) -> str:
+    """Skip rendering the title when called from the `node.children`."""
     return ""
 
 

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -5,6 +5,7 @@ Simple admonition
     *content*
 .
 !!! note
+
     *content*
 .
 
@@ -18,6 +19,7 @@ Could contain block elements too
 
 .
 !!! note
+
     ### heading
 
     ______________________________________________________________________
@@ -46,6 +48,7 @@ Shows no title
 
 .
 !!! note ""
+
     Some text
 
 .
@@ -60,10 +63,12 @@ Closes block after 2 empty lines
     A code block
 .
 !!! note
+
     Some text
 
-
-    A code block
+```
+A code block
+```
 .
 
 
@@ -76,10 +81,14 @@ Nested blocks
             code block
 .
 !!! note
+
     !!! note
+
         Some text
 
-            code block
+        ```
+        code block
+        ```
 .
 
 
@@ -91,7 +100,7 @@ Consecutive admonitions
 .
 !!! note
 
-!!! warning
+    !!! warning
 .
 
 
@@ -100,8 +109,11 @@ Marker may be indented up to 3 chars
    !!! note
        content
 .
-   !!! note
-       content
+```
+!!! note
+
+    content
+```
 .
 
 
@@ -110,8 +122,11 @@ But that's a code block
     !!! note
         content
 .
-    !!! note
-        content
+```
+!!! note
+
+    content
+```
 .
 
 
@@ -122,8 +137,9 @@ Some more indent checks
 
     code block
 .
-  !!! note
-   not a code block
+!!! note
+
+    not a code block
 
     code block
 .
@@ -135,9 +151,9 @@ Type could be adjacent to marker
    xxx
 
 .
-!!!note
-   xxx
+!!! note
 
+    xxx
 .
 
 
@@ -147,9 +163,9 @@ Type could be adjacent to marker and content may be shifted up to 3 chars
       xxx
 
 .
-!!!note
-      xxx
+!!! note
 
+    xxx
 .
 
 
@@ -158,8 +174,9 @@ Or several spaces apart
 !!!     note
         xxx
 .
-!!!     note
-        xxx
+!!! note
+
+    xxx
 .
 
 
@@ -169,6 +186,7 @@ Admonitions self-close at the end of the document
     xxx
 .
 !!! note
+
     xxx
 .
 
@@ -183,9 +201,11 @@ They could be nested in lists
       - d
 .
 - !!! note
+
       - a
       - b
 - !!! warning
+
       - c
       - d
 .
@@ -202,8 +222,7 @@ Or in blockquotes
 > !!! note
 >     xxx
 >     > yyy
->     zzz
->
+>     > zzz
 .
 
 
@@ -213,6 +232,7 @@ Renders unknown admonition type
     content
 .
 !!! unknown title
+
     content
 .
 
@@ -223,5 +243,5 @@ Does not render
     content
 .
 !!!
-    content
+content
 .

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -5,7 +5,6 @@ Simple admonition
     *content*
 .
 !!! note
-
     *content*
 .
 
@@ -19,7 +18,6 @@ Could contain block elements too
 
 .
 !!! note
-
     ### heading
 
     ______________________________________________________________________
@@ -48,7 +46,6 @@ Shows no title
 
 .
 !!! note ""
-
     Some text
 
 .
@@ -63,12 +60,10 @@ Closes block after 2 empty lines
     A code block
 .
 !!! note
-
     Some text
 
-```
-A code block
-```
+
+    A code block
 .
 
 
@@ -81,14 +76,10 @@ Nested blocks
             code block
 .
 !!! note
-
     !!! note
-
         Some text
 
-        ```
-        code block
-        ```
+            code block
 .
 
 
@@ -100,7 +91,7 @@ Consecutive admonitions
 .
 !!! note
 
-    !!! warning
+!!! warning
 .
 
 
@@ -109,11 +100,8 @@ Marker may be indented up to 3 chars
    !!! note
        content
 .
-```
-!!! note
-
-    content
-```
+   !!! note
+       content
 .
 
 
@@ -122,11 +110,8 @@ But that's a code block
     !!! note
         content
 .
-```
-!!! note
-
-    content
-```
+    !!! note
+        content
 .
 
 
@@ -137,9 +122,8 @@ Some more indent checks
 
     code block
 .
-!!! note
-
-    not a code block
+  !!! note
+   not a code block
 
     code block
 .
@@ -151,9 +135,9 @@ Type could be adjacent to marker
    xxx
 
 .
-!!! note
+!!!note
+   xxx
 
-    xxx
 .
 
 
@@ -163,9 +147,9 @@ Type could be adjacent to marker and content may be shifted up to 3 chars
       xxx
 
 .
-!!! note
+!!!note
+      xxx
 
-    xxx
 .
 
 
@@ -174,9 +158,8 @@ Or several spaces apart
 !!!     note
         xxx
 .
-!!! note
-
-    xxx
+!!!     note
+        xxx
 .
 
 
@@ -186,7 +169,6 @@ Admonitions self-close at the end of the document
     xxx
 .
 !!! note
-
     xxx
 .
 
@@ -201,11 +183,9 @@ They could be nested in lists
       - d
 .
 - !!! note
-
       - a
       - b
 - !!! warning
-
       - c
       - d
 .
@@ -222,7 +202,8 @@ Or in blockquotes
 > !!! note
 >     xxx
 >     > yyy
->     > zzz
+>     zzz
+>
 .
 
 
@@ -232,7 +213,6 @@ Renders unknown admonition type
     content
 .
 !!! unknown title
-
     content
 .
 
@@ -243,5 +223,5 @@ Does not render
     content
 .
 !!!
-content
+    content
 .

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{37,38,39,310}
 isolated_build = True
 
-[testenv:py{36,37,38,39}]
+[testenv:py{37,38,39,310}]
 extras = test
 commands = pytest {posargs}
 
-[testenv:py{36,37,38,39}-cov]
+[testenv:py{37,38,39,310}-cov]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/mdformat_admon {posargs}
 
-[testenv:py{36,37,38,39}-pre-commit]
+[testenv:py{37,38,39,310}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs:--all-files}
 
-[testenv:py{36,37,38,39}-hook]
+[testenv:py{37,38,39,310}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 


### PR DESCRIPTION
Working on what the output should be under the different test conditions

Drop Python 3.6, which doesn't have the `admonition` plugin in `0.3.2`