### PR TITLE
docs(#8): improve README and documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,11 @@
+---
 name: CI
 
 on:
   push:
     branches: [main]
     tags:
-      - 'v*'
+      - v*
   pull_request:
 
 jobs:
@@ -13,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.10'
-    - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v2.0.0
 
   tests:
     runs-on: ${{ matrix.os }}
@@ -28,51 +29,51 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Installation (deps and package)
+      - name: Installation (deps and package)
       # we install with flit --pth-file,
       # so that coverage will be recorded for the module
-      run: |
-        pip install flit
-        flit install --deps=production --extras=test --pth-file
+        run: |
+          pip install flit
+          flit install --deps=production --extras=test --pth-file
 
-    - name: Run pytest
-      run: |
-        pytest --cov=mdformat_admon --cov-report=xml --cov-report=term-missing
+      - name: Run pytest
+        run: |
+          pytest --cov=mdformat_admon --cov-report=xml --cov-report=term-missing
 
-    - name: Upload to Codecov
-      if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.7
-      uses: codecov/codecov-action@v1
-      with:
-        name: pytests-py3.7
-        flags: pytests
-        file: ./coverage.xml
-        fail_ci_if_error: true
+      - name: Upload to Codecov
+        if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.7
+        uses: codecov/codecov-action@v1
+        with:
+          name: pytests-py3.7
+          flags: pytests
+          file: ./coverage.xml
+          fail_ci_if_error: true
 
   pre-commit-hook:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
 
-    - name: Installation (deps and package)
-      run: |
-        pip install pre-commit
-        pip install .
+      - name: Installation (deps and package)
+        run: |
+          pip install pre-commit
+          pip install .
 
-    - name: run pre-commit with plugin
-      run: |
-        pre-commit run --config .pre-commit-test.yaml --all-files --verbose --show-diff-on-failure
+      - name: run pre-commit with plugin
+        run: |
+          pre-commit run --config .pre-commit-test.yaml --all-files --verbose --show-diff-on-failure
 
   publish:
     name: Publish to PyPi
@@ -80,18 +81,18 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: install flit
-      run: |
-        pip install flit~=3.0
-    - name: Build and publish
-      run: |
-        flit publish
-      env:
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: install flit
+        run: |
+          pip install flit~=3.0
+      - name: Build and publish
+        run: |
+          flit publish
+        env:
+          FLIT_USERNAME: __token__
+          FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, '3.10']
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -47,14 +47,14 @@ jobs:
         run: |
           pytest --cov=mdformat_admon --cov-report=xml --cov-report=term-missing
 
-      - name: Upload to Codecov
-        if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.7
-        uses: codecov/codecov-action@v1
-        with:
-          name: pytests-py3.7
-          flags: pytests
-          file: ./coverage.xml
-          fail_ci_if_error: true
+      # - name: Upload to Codecov
+      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.10
+      #   uses: codecov/codecov-action@v1
+      #   with:
+      #     name: pytests-py3.10
+      #     flags: pytests
+      #     file: ./coverage.xml
+      #     fail_ci_if_error: false
 
   pre-commit-hook:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,3 @@ repos:
       - id: yamlfix
         types_or: []
         types: [file, yaml]
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.22
-    hooks:
-      - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,32 +1,47 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-  - id: end-of-file-fixer
-  - id: mixed-line-ending
-  - id: trailing-whitespace
-  - id: check-yaml
-  - id: check-toml
-- repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
-  hooks:
-  - id: python-check-blanket-noqa
-- repo: https://github.com/timothycrosley/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
-- repo: https://github.com/psf/black
-  rev: 22.10.0
-  hooks:
-  - id: black
-- repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
-  hooks:
-  - id: flake8
-    additional_dependencies:
-    - flake8-bugbear>=21.3.2
-    - flake8-builtins>=1.5.3
-    - flake8-comprehensions>=3.4.0
-    args: [
-        --ignore=E501
-    ]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: end-of-file-fixer
+    - id: mixed-line-ending
+    - id: trailing-whitespace
+    - id: check-yaml
+    - id: check-toml
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+    - id: python-check-blanket-noqa
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+    - id: flake8
+      additional_dependencies:
+      - flake8-bugbear>=21.3.2
+      - flake8-builtins>=1.5.3
+      - flake8-comprehensions>=3.4.0
+      args: [
+          --ignore=E501
+      ]
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-admon
+          - mdformat-beautysh
+          - mdformat-black
+          - mdformat-config
+          - mdformat-frontmatter
+          - mdformat-gfm
+          - mdformat-tables
+          - mdformat-toc
+          - mdformat-web
+        args: [--wrap=no]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,51 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    - id: end-of-file-fixer
-    - id: mixed-line-ending
-    - id: trailing-whitespace
-    - id: check-yaml
-    - id: check-toml
+      - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-vcs-permalinks
+      - id: check-yaml
+        args: [--unsafe]
+      - id: debug-statements
+      - id: destroyed-symlinks
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: fix-encoding-pragma
+        args: [--remove]
+      - id: forbid-new-submodules
+      - id: mixed-line-ending
+        args: [--fix=auto]
+      - id: pretty-format-json
+        args: [--autofix, --indent=4]
+      - id: trailing-whitespace
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:
-    - id: python-check-blanket-noqa
+      - id: python-check-blanket-noqa
   - repo: https://github.com/timothycrosley/isort
     rev: 5.10.1
     hooks:
-    - id: isort
+      - id: isort
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
-    - id: black
+      - id: black
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
-    - id: flake8
-      additional_dependencies:
-      - flake8-bugbear>=21.3.2
-      - flake8-builtins>=1.5.3
-      - flake8-comprehensions>=3.4.0
-      args: [
-          --ignore=E501
-      ]
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear>=21.3.2
+          - flake8-builtins>=1.5.3
+          - flake8-comprehensions>=3.4.0
+        args: [--ignore=E501]
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
     hooks:
@@ -44,4 +60,15 @@ repos:
           - mdformat-tables
           - mdformat-toc
           - mdformat-web
+        exclude: tests/.+\.md
         args: [--wrap=no]
+  - repo: https://github.com/lyz-code/yamlfix/
+    rev: 1.1.1
+    hooks:
+      - id: yamlfix
+        types_or: []
+        types: [file, yaml]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.22
+    hooks:
+      - id: actionlint

--- a/.pre-commit-test.yaml
+++ b/.pre-commit-test.yaml
@@ -1,11 +1,12 @@
+---
 # A pre-commit hook for testing unreleased changes
 # Run from tox with: tox -e py310-hook
 repos:
   - repo: local
     hooks:
-    - id: mdformat
-      name: mdformat-from-tox
-      entry: mdformat
-      files: "tests/pre-commit-test.md"
-      types: [markdown]
-      language: system
+      - id: mdformat
+        name: mdformat-from-tox
+        entry: mdformat
+        files: tests/pre-commit-test.md
+        types: [markdown]
+        language: system

--- a/.pre-commit-test.yaml
+++ b/.pre-commit-test.yaml
@@ -1,8 +1,10 @@
+# A pre-commit hook for testing unreleased changes
+# Run from tox with: tox -e py310-hook
 repos:
   - repo: local
     hooks:
     - id: mdformat
-      name: mdformat
+      name: mdformat-from-tox
       entry: mdformat
       files: "tests/pre-commit-test.md"
       types: [markdown]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Development
+
+This package utilizes [flit](https://flit.readthedocs.io) as the build engine, and [tox](https://tox.readthedocs.io) for test automation.
+
+To install these development dependencies:
+
+```bash
+pip install tox
+```
+
+To run the tests:
+
+```bash
+tox
+```
+
+and with test coverage:
+
+```bash
+tox -e py37-cov
+```
+
+The easiest way to write tests, is to edit `tests/fixtures.md`
+
+To run the code formatting and style checks:
+
+```bash
+tox -e py37-pre-commit
+```
+
+or directly
+
+```bash
+pip install pre-commit
+pre-commit run --all
+```
+
+To run the pre-commit hook test:
+
+```bash
+tox -e py37-hook
+```
+
+## Publish to PyPi
+
+Either use flit directly:
+
+```bash
+pip install flit
+flit publish
+```
+
+or trigger the GitHub Action job, by creating a release with a tag equal to the version, e.g. `v0.0.1`.
+
+Note, this requires generating an API key on PyPi and adding it to the repository `Settings/Secrets`, under the name `PYPI_KEY`.

--- a/README.md
+++ b/README.md
@@ -1,66 +1,51 @@
 # mdformat-admon
 
-[![Build Status][ci-badge]][ci-link]
-[![codecov.io][cov-badge]][cov-link]
-[![PyPI version][pypi-badge]][pypi-link]
+[![Build Status][ci-badge]][ci-link] [![codecov.io][cov-badge]][cov-link] [![PyPI version][pypi-badge]][pypi-link]
 
 An [mdformat](https://github.com/executablebooks/mdformat) plugin for admonitions.
 
-## Development
+## Usage
 
-This package utilizes [flit](https://flit.readthedocs.io) as the build engine, and [tox](https://tox.readthedocs.io) for test automation.
+Add this package wherever you use `mdformat` and the plugin will be auto-recognized. No additional configuration necessary. See [additional information on `mdformat` plugins here](https://mdformat.readthedocs.io/en/stable/users/plugins.html)
 
-To install these development dependencies:
+### Pre-commit
 
-```bash
-pip install tox
+```yaml
+repos:
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-admon
 ```
 
-To run the tests:
+### pipx
 
-```bash
-tox
+```sh
+pipx install mdformat
+pipx inject mdformat mdformat-admon
 ```
 
-and with test coverage:
+## Caveats
 
-```bash
-tox -e py37-cov
-```
+This plugin currently only supports admonitions that start with `!!! ...` and won't modify admonitions for Github, which should cover most use cases. Future work is planned for other types.
 
-The easiest way to write tests, is to edit `tests/fixtures.md`
+See the example test file: [./tests/pre-commit-test.md](https://raw.githubusercontent.com/KyleKing/mdformat-admon/main/tests/pre-commit-test.md)
 
-To run the code formatting and style checks:
+As a quick summary:
 
-```bash
-tox -e py37-pre-commit
-```
+- [python-markdown](https://python-markdown.github.io/extensions/admonition/): are fully supported by `mdformat-admon` and tested extensively in [./tests/fixtures.md](https://raw.githubusercontent.com/KyleKing/mdformat-admon/main/tests/fixtures.md)
+- [MKdocs](https://squidfunk.github.io/mkdocs-material/reference/admonitions): Only `!!!`-blocks are supported (#9)
+- [Github](https://github.com/orgs/community/discussions/16925): Unsupported and will not modify
+- [reStructuredText](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions): Unsupported and *will break*
+- [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html): Unsupported and will not modify
+- [Remark-Admonitions](https://github.com/elviswolcott/remark-admonitions): Unsupported and will not modify
+- [Obsidian Callouts](https://help.obsidian.md/How+to/Use+callouts): Unsupported and *will break* because `mdformat` adds extra characters
 
-or directly
+## Contributing
 
-```bash
-pip install pre-commit
-pre-commit run --all
-```
-
-To run the pre-commit hook test:
-
-```bash
-tox -e py37-hook
-```
-
-## Publish to PyPi
-
-Either use flit directly:
-
-```bash
-pip install flit
-flit publish
-```
-
-or trigger the GitHub Action job, by creating a release with a tag equal to the version, e.g. `v0.0.1`.
-
-Note, this requires generating an API key on PyPi and adding it to the repository `Settings/Secrets`, under the name `PYPI_KEY`.
+See [CONTRIBUTING.md](https://github.com/KyleKing/mdformat-admon/blob/main/CONTRIBUTING.md)
 
 [ci-badge]: https://github.com/executablebooks/mdformat-admon/workflows/CI/badge.svg?branch=main
 [ci-link]: https://github.com/executablebooks/mdformat/actions?query=workflow%3ACI+branch%3Amain+event%3Apush

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # mdformat-admon
 
-[![Build Status][ci-badge]][ci-link] [![codecov.io][cov-badge]][cov-link] [![PyPI version][pypi-badge]][pypi-link]
+[![Build Status][ci-badge]][ci-link]
+
+<!-- [![codecov.io][cov-badge]][cov-link]
+[cov-badge]: https://codecov.io/gh/executablebooks/mdformat-admon/branch/main/graph/badge.svg
+[cov-link]: https://codecov.io/gh/executablebooks/mdformat-admon
+ -->
+
+[![PyPI version][pypi-badge]][pypi-link]
 
 An [mdformat](https://github.com/executablebooks/mdformat) plugin for admonitions.
 
@@ -49,7 +56,5 @@ See [CONTRIBUTING.md](https://github.com/KyleKing/mdformat-admon/blob/main/CONTR
 
 [ci-badge]: https://github.com/executablebooks/mdformat-admon/workflows/CI/badge.svg?branch=main
 [ci-link]: https://github.com/executablebooks/mdformat/actions?query=workflow%3ACI+branch%3Amain+event%3Apush
-[cov-badge]: https://codecov.io/gh/executablebooks/mdformat-admon/branch/main/graph/badge.svg
-[cov-link]: https://codecov.io/gh/executablebooks/mdformat-admon
 [pypi-badge]: https://img.shields.io/pypi/v/mdformat-admon.svg
 [pypi-link]: https://pypi.org/project/mdformat-admon

--- a/mdformat_admon/__init__.py
+++ b/mdformat_admon/__init__.py
@@ -1,5 +1,5 @@
 """An mdformat plugin for admonitions."""
 
-__version__ = "1.0.0"
+__version__ = "0.0.1"
 
 from .plugin import RENDERERS, update_mdit  # noqa: F401

--- a/mdformat_admon/__init__.py
+++ b/mdformat_admon/__init__.py
@@ -1,4 +1,4 @@
-"""An mdformat plugin for..."""
+"""An mdformat plugin for admonitions."""
 
 __version__ = "1.0.0"
 

--- a/mdformat_admon/__init__.py
+++ b/mdformat_admon/__init__.py
@@ -1,5 +1,5 @@
 """An mdformat plugin for..."""
 
-__version__ = "0.0.1"
+__version__ = "1.0.0"
 
 from .plugin import RENDERERS, update_mdit  # noqa: F401

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -232,3 +232,34 @@ Does not render
 !!!
 content
 .
+
+
+
+FIXME: MKdocs Closed Collapsible Sections
+.
+??? note
+    content
+.
+??? note
+content
+.
+
+
+FIXME: MKdocs Open Collapsible Sections
+.
+???+ note
+    content
+.
+???+ note
+content
+.
+
+
+FIXME: reStructuredText Dot-Syntax
+.
+.. directivename:: arguments
+   :key1: val1
+.
+.. directivename:: arguments
+:key1: val1
+.

--- a/tests/pre-commit-test.md
+++ b/tests/pre-commit-test.md
@@ -1,6 +1,6 @@
-# Test file
+# Pre-Commit Test File
 
-add your syntax here
+Testing `mdformat-admon` as a `pre-commit` hook (`tox -e py#-hook`)
 
 ## `!!!`-based Admonitions
 
@@ -37,10 +37,9 @@ From: https://python-markdown.github.io/extensions/admonition/
 > **Warning**
 > This is a warning
 
-
 ## RST
 
-**STATUS: Unsupported and *may break***
+**STATUS: Unsupported and *may break*** like the 3rd and 4th examples below
 
 From: https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions
 
@@ -48,47 +47,50 @@ From: https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admo
 
 .. contents:: Table of Contents
 
+```rst
 .. contents:: Here's a very long Table of
    Contents title
+```
 
+```rst
 .. contents:: Table of Contents
    :depth: 2
+```
 
 ## MKdocs
 
-**STATUS: Partially supported, but *may break***
+**STATUS: ONly `!!!`-blocks are supported**
 
 Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions/#removing-the-title
 
 ### Default
 
 !!! note
-
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
     nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
     massa, nec semper lorem quam in massa.
-
 
 ### Collapsible
 
+Not currently supported
 
+```md
 ??? note
-
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
     nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
     massa, nec semper lorem quam in massa.
+```
 
-
+```md
 ???+ note
-
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
     nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
     massa, nec semper lorem quam in massa.
+```
 
 ### Inline
 
 !!! info inline end
-
     Lorem ipsum dolor sit amet, consectetur
     adipiscing elit. Nulla et euismod nulla.
     Curabitur feugiat, tortor non consequat
@@ -98,7 +100,6 @@ Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions/#rem
 ### Custom Type
 
 !!! pied-piper "Pied Piper"
-
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et
     euismod nulla. Curabitur feugiat, tortor non consequat finibus, justo
     purus auctor massa, nec semper lorem quam in massa.

--- a/tests/pre-commit-test.md
+++ b/tests/pre-commit-test.md
@@ -1,3 +1,104 @@
 # Test file
 
 add your syntax here
+
+## `!!!`-based Admonitions
+
+**STATUS: Full support for formatting by `mdformat-admon`**
+
+### Python-Markdown
+
+From: https://python-markdown.github.io/extensions/admonition/
+
+!!! type "optional explicit title within double quotes"
+    Any number of other indented markdown elements.
+
+    This is the second paragraph.
+
+!!! note
+    You should note that the title will be automatically capitalized.
+
+!!! danger "Don't try this at home"
+    ...
+
+!!! important ""
+    This is an admonition box without a title.
+
+!!! danger highlight blink "Don't try this at home"
+    ...
+
+## Github
+
+**STATUS: Unsupported and will not modify**
+
+> **Note**
+> This is a note
+
+> **Warning**
+> This is a warning
+
+
+## RST
+
+**STATUS: Unsupported and *may break***
+
+From: https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions
+
+.. contents::
+
+.. contents:: Table of Contents
+
+.. contents:: Here's a very long Table of
+   Contents title
+
+.. contents:: Table of Contents
+   :depth: 2
+
+## MKdocs
+
+**STATUS: Partially supported, but *may break***
+
+Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions/#removing-the-title
+
+### Default
+
+!!! note
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
+    nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
+    massa, nec semper lorem quam in massa.
+
+
+### Collapsible
+
+
+??? note
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
+    nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
+    massa, nec semper lorem quam in massa.
+
+
+???+ note
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
+    nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
+    massa, nec semper lorem quam in massa.
+
+### Inline
+
+!!! info inline end
+
+    Lorem ipsum dolor sit amet, consectetur
+    adipiscing elit. Nulla et euismod nulla.
+    Curabitur feugiat, tortor non consequat
+    finibus, justo purus auctor massa, nec
+    semper lorem quam in massa.
+
+### Custom Type
+
+!!! pied-piper "Pied Piper"
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et
+    euismod nulla. Curabitur feugiat, tortor non consequat finibus, justo
+    purus auctor massa, nec semper lorem quam in massa.

--- a/tests/pre-commit-test.md
+++ b/tests/pre-commit-test.md
@@ -2,11 +2,13 @@
 
 Testing `mdformat-admon` as a `pre-commit` hook (`tox -e py#-hook`)
 
-## `!!!`-based Admonitions
+## CommonMark
+
+[Does not specify a syntax for admonitions](https://spec.commonmark.org)
+
+## Python-Markdown
 
 **STATUS: Full support for formatting by `mdformat-admon`**
-
-### Python-Markdown
 
 From: https://python-markdown.github.io/extensions/admonition/
 
@@ -27,41 +29,11 @@ From: https://python-markdown.github.io/extensions/admonition/
 !!! danger highlight blink "Don't try this at home"
     ...
 
-## Github
-
-**STATUS: Unsupported and will not modify**
-
-> **Note**
-> This is a note
-
-> **Warning**
-> This is a warning
-
-## RST
-
-**STATUS: Unsupported and *may break*** like the 3rd and 4th examples below
-
-From: https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions
-
-.. contents::
-
-.. contents:: Table of Contents
-
-```rst
-.. contents:: Here's a very long Table of
-   Contents title
-```
-
-```rst
-.. contents:: Table of Contents
-   :depth: 2
-```
-
 ## MKdocs
 
-**STATUS: ONly `!!!`-blocks are supported**
+**STATUS: Only `!!!`-blocks are supported**
 
-Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions/#removing-the-title
+Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions
 
 ### Default
 
@@ -72,7 +44,7 @@ Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions/#rem
 
 ### Collapsible
 
-Not currently supported
+**Not currently supported**
 
 ```md
 ??? note
@@ -103,3 +75,150 @@ Not currently supported
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et
     euismod nulla. Curabitur feugiat, tortor non consequat finibus, justo
     purus auctor massa, nec semper lorem quam in massa.
+
+## Github
+
+**STATUS: Unsupported and will not modify**
+
+> **Note**
+> This is a note
+
+> **Warning**
+>
+> This is a warning
+
+## reStructuredText
+
+**STATUS: Unsupported and *will break*** like the 3rd, 4th, and 5th examples below
+
+From: https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions
+
+.. contents::
+
+.. contents:: Table of Contents
+
+```rst
+.. contents:: Here's a very long Table of
+   Contents title
+```
+
+```rst
+.. contents:: Table of Contents
+   :depth: 2
+```
+
+From: https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html
+
+```
+.. directivename:: arguments
+   :key1: val1
+   :key2: val2
+
+   This is
+   directive content
+```
+
+## MyST
+
+**STATUS: Unsupported and will not modify**
+
+From: https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html
+
+```{directivename} arguments
+---
+key1: val1
+key2: val2
+---
+This is
+directive content
+```
+
+```{code-block} python
+---
+lineno-start: 10
+emphasize-lines: 1, 3
+caption: |
+    This is my
+    multi-line caption. It is *pretty nifty* ;-)
+---
+a = 2
+print('my 1st line')
+print(f'my {a}nd line')
+```
+
+```{admonition} My markdown link
+Here is [markdown link syntax](https://jupyter.org)
+```
+
+```{eval-rst}
+.. figure:: img/fun-fish.png
+  :width: 100px
+  :name: rst-fun-fish
+
+  Party time!
+
+A reference from inside: :ref:`rst-fun-fish`
+
+A reference from outside: :ref:`syntax/directives/parsing`
+```
+
+````{note}
+The warning block will be properly-parsed
+
+   ```{warning}
+   Here's my warning
+   ```
+
+But the next block will be parsed as raw text
+
+    ```{warning}
+    Here's my raw text warning that isn't parsed...
+    ```
+````
+
+## Remark-Admonitions
+
+**STATUS: Unsupported and will not modify**
+
+From: https://github.com/elviswolcott/remark-admonitions
+
+:::tip pro tip
+`remark-admonitions` is pretty great!
+:::
+
+## Obsidian
+
+## (New) Callouts
+
+**STATUS: Unsupported and *will break*** because `mdformat` adds extra characters
+
+From: https://help.obsidian.md/How+to/Use+callouts
+
+```
+> [!INFO]
+> Here's a callout block.
+> It supports **markdown**, [[Internal link|wikilinks]], and [[Embed files|embeds]]!
+> ![[og-image.png]]
+```
+
+```
+> [!question] Can callouts be nested?
+> > [!todo] Yes!, they can.
+> > > [!example]  You can even use multiple layers of nesting.
+```
+
+## (Old) Plugin
+
+**STATUS: Unsupported and will not modify**
+
+From: https://github.com/valentine195/obsidian-admonition
+
+```ad-<type> # Admonition type. See below for a list of available types.
+title:                  # Admonition title.
+collapse:               # Create a collapsible admonition.
+icon:                   # Override the icon.
+color:                  # Override the color.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod nulla.
+
+```


### PR DESCRIPTION
Resolves: #8

See discussion: https://github.com/KyleKing/mdformat-admon/pull/4#discussion_r1049566735

- [x] Document what admonition types are supported in README and link to the test fixtures
- [x] Add unit tests for unsupported (Github, etc.)
- [x] Add unit tests for planned-to-be supported (`mkdocs`?)
- [x] Consider updating the `mdit-py-plugin` to support full range of `mkdocs`
- [x] Possibly some additional research to see what else is out there