### PR TITLE
Support MkDocs ??? and ???+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
 
 jobs:
-
   pre-commit:
     runs-on: ubuntu-latest
 
@@ -37,8 +36,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Installation (deps and package)
-      # we install with flit --pth-file,
-      # so that coverage will be recorded for the module
+        # we install with flit --pth-file,
+        # so that coverage will be recorded for the module
         run: |
           pip install flit
           flit install --deps=production --extras=test --pth-file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,16 +25,17 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
       - id: trailing-whitespace
+        exclude: tests/fixtures.*\.md
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:
       - id: python-check-blanket-noqa
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -51,15 +52,7 @@ repos:
     hooks:
       - id: mdformat
         additional_dependencies:
-          - mdformat-admon
-          - mdformat-beautysh
-          - mdformat-black
-          - mdformat-config
-          - mdformat-frontmatter
-          - mdformat-gfm
-          - mdformat-tables
-          - mdformat-toc
-          - mdformat-web
+          - mdformat-mkdocs[recommended]
         exclude: tests/.+\.md
         args: [--wrap=no]
   - repo: https://github.com/lyz-code/yamlfix/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # mdformat-admon
 
-[![Build Status][ci-badge]][ci-link]
+[![Build Status][ci-badge]][ci-link] [![PyPI version][pypi-badge]][pypi-link]
 
 <!-- [![codecov.io][cov-badge]][cov-link]
 [cov-badge]: https://codecov.io/gh/executablebooks/mdformat-admon/branch/main/graph/badge.svg
 [cov-link]: https://codecov.io/gh/executablebooks/mdformat-admon
  -->
-
-[![PyPI version][pypi-badge]][pypi-link]
 
 An [mdformat](https://github.com/executablebooks/mdformat) plugin for admonitions.
 
@@ -42,13 +40,14 @@ See the example test file: [./tests/pre-commit-test.md](https://raw.githubuserco
 
 As a quick summary:
 
-- [python-markdown](https://python-markdown.github.io/extensions/admonition/): are fully supported by `mdformat-admon` and tested extensively in [./tests/fixtures.md](https://raw.githubusercontent.com/KyleKing/mdformat-admon/main/tests/fixtures.md)
-- [MKdocs](https://squidfunk.github.io/mkdocs-material/reference/admonitions): Only `!!!`-blocks are supported (#9)
+- [python-markdown](https://python-markdown.github.io/extensions/admonition/): is fully supported by `mdformat-admon` and tested extensively in [./tests/fixtures.md](https://raw.githubusercontent.com/KyleKing/mdformat-admon/main/tests/fixtures.md)
+- [MKdocs](https://squidfunk.github.io/mkdocs-material/reference/admonitions): Is fully supported
 - [Github](https://github.com/orgs/community/discussions/16925): Unsupported and will not modify
-- [reStructuredText](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions): Unsupported and *will break*
 - [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html): Unsupported and will not modify
 - [Remark-Admonitions](https://github.com/elviswolcott/remark-admonitions): Unsupported and will not modify
-- [Obsidian Callouts](https://help.obsidian.md/How+to/Use+callouts): Unsupported and *will break* because `mdformat` adds extra characters
+- `mdformat` will break admonitions by:
+  - [reStructuredText](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions): Unsupported and *will break*
+  - [Obsidian Callouts](https://help.obsidian.md/How+to/Use+callouts): Unsupported and *will break* because `mdformat` adds extra characters
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ As a quick summary:
 
 - [python-markdown](https://python-markdown.github.io/extensions/admonition/): is fully supported by `mdformat-admon` and tested extensively in [./tests/fixtures.md](https://raw.githubusercontent.com/KyleKing/mdformat-admon/main/tests/fixtures.md)
 - [MKdocs](https://squidfunk.github.io/mkdocs-material/reference/admonitions): Is fully supported
-- [Github](https://github.com/orgs/community/discussions/16925): Unsupported and will not modify
-- [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html): Unsupported and will not modify
-- [Remark-Admonitions](https://github.com/elviswolcott/remark-admonitions): Unsupported and will not modify
+- Unsupported, but won't modify:
+  - [Github](https://github.com/orgs/community/discussions/16925): Unsupported and will not modify
+  - [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html): Unsupported and will not modify
+  - [Remark-Admonitions](https://github.com/elviswolcott/remark-admonitions): Unsupported and will not modify
 - `mdformat` will break admonitions by:
-  - [reStructuredText](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions): Unsupported and *will break*
+  - [reStructuredText](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions): Unsupported and *will break* by removing or modifying indentation
   - [Obsidian Callouts](https://help.obsidian.md/How+to/Use+callouts): Unsupported and *will break* because `mdformat` adds extra characters
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ As a quick summary:
 - [python-markdown](https://python-markdown.github.io/extensions/admonition/): is fully supported by `mdformat-admon` and tested extensively in [./tests/fixtures.md](https://raw.githubusercontent.com/KyleKing/mdformat-admon/main/tests/fixtures.md)
 - [MKdocs](https://squidfunk.github.io/mkdocs-material/reference/admonitions): Is fully supported
 - Unsupported, but won't modify:
-  - [Github](https://github.com/orgs/community/discussions/16925): Unsupported and will not modify
-  - [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html): Unsupported and will not modify
-  - [Remark-Admonitions](https://github.com/elviswolcott/remark-admonitions): Unsupported and will not modify
+    - [Github](https://github.com/orgs/community/discussions/16925): Unsupported and will not modify
+    - [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html): Unsupported and will not modify
+    - [Remark-Admonitions](https://github.com/elviswolcott/remark-admonitions): Unsupported and will not modify
 - `mdformat` will break admonitions by:
-  - [reStructuredText](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions): Unsupported and *will break* by removing or modifying indentation
-  - [Obsidian Callouts](https://help.obsidian.md/How+to/Use+callouts): Unsupported and *will break* because `mdformat` adds extra characters
+    - [reStructuredText](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions): Unsupported and *will break* by removing or modifying indentation
+    - [Obsidian Callouts](https://help.obsidian.md/How+to/Use+callouts): Unsupported and *will break* because `mdformat` adds extra characters
 
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/KyleKing/mdformat-admon/blob/main/CONTRIBUTING.md)
 
-[ci-badge]: https://github.com/executablebooks/mdformat-admon/workflows/CI/badge.svg?branch=main
-[ci-link]: https://github.com/executablebooks/mdformat/actions?query=workflow%3ACI+branch%3Amain+event%3Apush
+[ci-badge]: https://github.com/kyleking/mdformat-admon/workflows/CI/badge.svg?branch=main
+[ci-link]: https://github.com/kyleking/mdformat-admon/actions?query=workflow%3ACI+branch%3Amain+event%3Apush
 [pypi-badge]: https://img.shields.io/pypi/v/mdformat-admon.svg
 [pypi-link]: https://pypi.org/project/mdformat-admon

--- a/mdformat_admon/__init__.py
+++ b/mdformat_admon/__init__.py
@@ -1,5 +1,5 @@
 """An mdformat plugin for admonitions."""
 
-__version__ = "0.0.1"
+__version__ = "1.0.0"
 
 from .plugin import RENDERERS, update_mdit  # noqa: F401

--- a/mdformat_admon/index_pr58.py
+++ b/mdformat_admon/index_pr58.py
@@ -1,0 +1,173 @@
+# Process admonitions and pass to cb.
+
+from typing import Callable, Optional, Tuple
+
+from markdown_it import MarkdownIt
+from markdown_it.rules_block import StateBlock
+
+
+def get_tag(params: str) -> Tuple[str, str]:
+    if not params.strip():
+        return "", ""
+
+    tag, *_title = params.strip().split(" ")
+    joined = " ".join(_title)
+
+    title = ""
+    if not joined:
+        title = tag.title()
+    elif joined != '""':
+        title = joined
+    return tag.lower(), title
+
+
+def validate(params: str) -> bool:
+    tag = params.strip().split(" ", 1)[-1] or ""
+    return bool(tag)
+
+
+MARKERS = ("!!!", "???", "???+")
+MARKER_CHARS = {_m[0] for _m in MARKERS}
+MAX_MARKER_LEN = max(len(_m) for _m in MARKERS)
+
+
+def admonition(  # noqa: C901
+    state: StateBlock, startLine: int, endLine: int, silent: bool
+) -> bool:
+    start = state.bMarks[startLine] + state.tShift[startLine]
+    maximum = state.eMarks[startLine]
+
+    # Check out the first character quickly, which should filter out most of non-containers
+    if state.src[start] not in MARKER_CHARS:
+        return False
+
+    # Check out the rest of the marker string
+    marker_len = MAX_MARKER_LEN
+    while marker_len > 0:
+        marker_pos = start + marker_len
+        markup = state.src[start:marker_pos]
+        if markup in MARKERS:
+            break
+        marker_len -= 1
+    else:
+        return False
+
+    params = state.src[marker_pos:maximum]
+
+    if not validate(params):
+        return False
+
+    # Since start is found, we can report success here in validation mode
+    if silent:
+        return True
+
+    old_parent = state.parentType
+    old_line_max = state.lineMax
+    old_indent = state.blkIndent
+
+    blk_start = marker_pos
+    while blk_start < maximum and state.src[blk_start] == " ":
+        blk_start += 1
+
+    state.parentType = "admonition"
+    state.blkIndent += blk_start - start
+
+    was_empty = False
+
+    # Search for the end of the block
+    next_line = startLine
+    while True:
+        next_line += 1
+        if next_line >= endLine:
+            # unclosed block should be autoclosed by end of document.
+            # also block seems to be autoclosed by end of parent
+            break
+        pos = state.bMarks[next_line] + state.tShift[next_line]
+        maximum = state.eMarks[next_line]
+        is_empty = state.sCount[next_line] < state.blkIndent
+
+        # two consecutive empty lines autoclose the block
+        if is_empty and was_empty:
+            break
+        was_empty = is_empty
+
+        if pos < maximum and state.sCount[next_line] < state.blkIndent:
+            # non-empty line with negative indent should stop the block:
+            # - !!!
+            #  test
+            break
+
+    # this will prevent lazy continuations from ever going past our end marker
+    state.lineMax = next_line
+
+    tag, title = get_tag(params)
+
+    token = state.push("admonition_open", "div", 1)
+    token.markup = markup
+    token.block = True
+    token.attrs = {"class": f"admonition {tag}"}
+    token.meta = {"tag": tag}
+    token.content = title
+    token.info = params
+    token.map = [startLine, next_line]
+
+    if title:
+        title_markup = f"{markup} {tag}"
+        token = state.push("admonition_title_open", "p", 1)
+        token.markup = title_markup
+        token.attrs = {"class": "admonition-title"}
+        token.map = [startLine, startLine + 1]
+
+        token = state.push("inline", "", 0)
+        token.content = title
+        token.map = [startLine, startLine + 1]
+        token.children = []
+
+        token = state.push("admonition_title_close", "p", -1)
+        token.markup = title_markup
+
+    state.md.block.tokenize(state, startLine + 1, next_line)
+
+    token = state.push("admonition_close", "div", -1)
+    token.markup = markup
+    token.block = True
+
+    state.parentType = old_parent
+    state.lineMax = old_line_max
+    state.blkIndent = old_indent
+    state.line = next_line
+
+    return True
+
+
+def admon_plugin(md: MarkdownIt, render: Optional[Callable] = None) -> None:
+    """Plugin to use
+    `python-markdown style admonitions
+    <https://python-markdown.github.io/extensions/admonition>`_.
+
+    .. code-block:: md
+
+        !!! note
+            *content*
+
+    Note, this is ported from
+    `markdown-it-admon
+    <https://github.com/commenthol/markdown-it-admon>`_.
+    """
+
+    def renderDefault(self, tokens, idx, _options, env):
+        return self.renderToken(tokens, idx, _options, env)
+
+    render = render or renderDefault
+
+    md.add_render_rule("admonition_open", render)
+    md.add_render_rule("admonition_close", render)
+    md.add_render_rule("admonition_title_open", render)
+    md.add_render_rule("admonition_title_close", render)
+
+    md.block.ruler.before(
+        "fence",
+        "admonition",
+        admonition,
+        {"alt": ["paragraph", "reference", "blockquote", "list"]},
+    )

--- a/mdformat_admon/index_pr58.py
+++ b/mdformat_admon/index_pr58.py
@@ -26,6 +26,7 @@ def validate(params: str) -> bool:
     return bool(tag)
 
 
+MARKER_LEN = 3  # Regardless of extra characters, block indent stays the same
 MARKERS = ("!!!", "???", "???+")
 MARKER_CHARS = {_m[0] for _m in MARKERS}
 MAX_MARKER_LEN = max(len(_m) for _m in MARKERS)
@@ -42,11 +43,13 @@ def admonition(  # noqa: C901
         return False
 
     # Check out the rest of the marker string
+    marker = ""
     marker_len = MAX_MARKER_LEN
     while marker_len > 0:
         marker_pos = start + marker_len
         markup = state.src[start:marker_pos]
         if markup in MARKERS:
+            marker = markup
             break
         marker_len -= 1
     else:
@@ -70,7 +73,9 @@ def admonition(  # noqa: C901
         blk_start += 1
 
     state.parentType = "admonition"
-    state.blkIndent += blk_start - start
+    # Correct block indentation when extra marker characters are present
+    marker_alignment_correction = MARKER_LEN - len(marker)
+    state.blkIndent += blk_start - start + marker_alignment_correction
 
     was_empty = False
 

--- a/mdformat_admon/plugin.py
+++ b/mdformat_admon/plugin.py
@@ -8,7 +8,7 @@ from mdit_py_plugins.admon import admon_plugin
 
 
 def update_mdit(mdit: MarkdownIt) -> None:
-    """Update the parser,"""
+    """Update the parser."""
     mdit.use(admon_plugin)
 
 
@@ -35,7 +35,7 @@ def _render_admon(node: RenderTreeNode, context: RenderContext) -> str:
     with context.indented(len(indent)):  # Modifies context.env['indent_width']
         elements = [child.render(context) for child in node.children]
     separator = "\n\n"
-    content = textwrap.indent(separator.join(e for e in elements if e), indent)
+    content = textwrap.indent(separator.join(_e for _e in elements if _e), indent)
     return title_line + "\n" + content if content else title_line
 
 

--- a/mdformat_admon/plugin.py
+++ b/mdformat_admon/plugin.py
@@ -4,7 +4,11 @@ from typing import Mapping
 from markdown_it import MarkdownIt
 from mdformat.renderer import RenderContext, RenderTreeNode
 from mdformat.renderer.typing import Render
-from mdit_py_plugins.admon import admon_plugin
+
+from .index_pr58 import admon_plugin
+
+# FIXME: Use latest mdit_py_pluign once my PR is merged
+#   https://github.com/executablebooks/mdit-py-plugins/pull/58/files
 
 
 def update_mdit(mdit: MarkdownIt) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,13 @@ classifiers = [
 keywords = ["mdformat", "markdown", "markdown-it"]
 requires-python = ">=3.7.2"
 dependencies = [
-    "mdformat >=0.7.0,<0.8.0",
-    "mdit-py-plugins >=0.3.2",
+    "mdformat >= 0.7.16",
 ]
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 test = [
-    "pytest>=6.0",
+    "pytest >= 7.0",
     "pytest-cov",
 ]
 dev = ["pre-commit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "mdformat_admon"
 authors = [
-    { name = "Chris Sewell", email = "executablebooks@gmail.com" },
+    { name = "Kyle King", email = "dev.act.kyle@gmail.com" },
 ]
 readme = "README.md"
 classifiers = [
@@ -22,7 +22,7 @@ dependencies = [
 ]
 dynamic = ["version", "description"]
 
-[project.optional-dependencies]
+[tool.flit.metadata.requires-extra]
 test = [
     "pytest>=6.0",
     "pytest-cov",
@@ -30,7 +30,7 @@ test = [
 dev = ["pre-commit"]
 
 [project.urls]
-Homepage = "https://github.com/executablebooks/mdformat-admon"
+Homepage = "https://github.com/KyleKing/mdformat-admon"
 
 [project.entry-points."mdformat.parser_extension"]
 admonition = "mdformat_admon"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 dynamic = ["version", "description"]
 
-[tool.flit.metadata.requires-extra]
+[project.optional-dependencies]
 test = [
     "pytest>=6.0",
     "pytest-cov",

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -235,31 +235,21 @@ content
 
 
 
-FIXME: MKdocs Closed Collapsible Sections
+MKdocs Closed Collapsible Sections
 .
 ??? note
     content
 .
 ??? note
-content
+    content
 .
 
 
-FIXME: MKdocs Open Collapsible Sections
+MKdocs Open Collapsible Sections
 .
 ???+ note
     content
 .
 ???+ note
-content
-.
-
-
-FIXME: reStructuredText Dot-Syntax
-.
-.. directivename:: arguments
-   :key1: val1
-.
-.. directivename:: arguments
-:key1: val1
+    content
 .

--- a/tests/pre-commit-test.md
+++ b/tests/pre-commit-test.md
@@ -31,7 +31,7 @@ From: https://python-markdown.github.io/extensions/admonition/
 
 ## MKdocs
 
-**STATUS: Only `!!!`-blocks are supported**
+**STATUS: Fully supported**
 
 Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions
 
@@ -44,21 +44,15 @@ Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions
 
 ### Collapsible
 
-**Not currently supported**
-
-```md
 ??? note
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
     nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
     massa, nec semper lorem quam in massa.
-```
 
-```md
 ???+ note
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
     nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
     massa, nec semper lorem quam in massa.
-```
 
 ### Inline
 
@@ -86,37 +80,6 @@ Based on: https://squidfunk.github.io/mkdocs-material/reference/admonitions
 > **Warning**
 >
 > This is a warning
-
-## reStructuredText
-
-**STATUS: Unsupported and *will break*** like the 3rd, 4th, and 5th examples below
-
-From: https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions
-
-.. contents::
-
-.. contents:: Table of Contents
-
-```rst
-.. contents:: Here's a very long Table of
-   Contents title
-```
-
-```rst
-.. contents:: Table of Contents
-   :depth: 2
-```
-
-From: https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html
-
-```
-.. directivename:: arguments
-   :key1: val1
-   :key2: val2
-
-   This is
-   directive content
-```
 
 ## MyST
 
@@ -185,6 +148,37 @@ From: https://github.com/elviswolcott/remark-admonitions
 :::tip pro tip
 `remark-admonitions` is pretty great!
 :::
+
+## reStructuredText
+
+**STATUS: Unsupported and *will break*** like the 3rd, 4th, and 5th examples below
+
+From: https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions
+
+.. contents::
+
+.. contents:: Table of Contents
+
+```rst
+.. contents:: Here's a very long Table of
+   Contents title
+```
+
+```rst
+.. contents:: Table of Contents
+   :depth: 2
+```
+
+From: https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html
+
+```
+.. directivename:: arguments
+   :key1: val1
+   :key2: val2
+
+   This is
+   directive content
+```
 
 ## Obsidian
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,29 @@
 [tox]
-envlist = py{37,38,39,310}
+envlist =
+    py{310}-cov
+    py{37}-recommended
+    py{310}-pre-commit
+    py{37,310}-hook
 isolated_build = True
+skip_missing_interpreters = False
 
-[testenv:py{37,38,39,310}]
+[testenv:py{310}]
 extras = test
-commands = pytest {posargs}
+commands = pytest {posargs} --ff -vv
 
-[testenv:py{37,38,39,310}-cov]
+[testenv:py{310}-cov]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/mdformat_admon {posargs}
 
-[testenv:py{37,38,39,310}-pre-commit]
+[testenv:py{37}-recommended]
+extras = recommended,test
+commands = pytest {posargs} --ff -vv
+
+[testenv:py{310}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs:--all-files}
 
-[testenv:py{37,38,39,310}-hook]
+[testenv:py{37,310}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,18 @@
 [tox]
 envlist =
-    py{310}-cov
-    py{37}-recommended
+    py{37,310}-cov
     py{310}-pre-commit
     py{37,310}-hook
 isolated_build = True
 skip_missing_interpreters = False
 
-[testenv:py{310}]
+[testenv:py{37,310}]
 extras = test
 commands = pytest {posargs} --ff -vv
 
 [testenv:py{310}-cov]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/mdformat_admon {posargs}
-
-[testenv:py{37}-recommended]
-extras = recommended,test
-commands = pytest {posargs} --ff -vv
 
 [testenv:py{310}-pre-commit]
 extras = dev


### PR DESCRIPTION
~~Blocked by: https://github.com/executablebooks/mdit-py-plugins/pull/58~~ (Went ahead and copied over the code to make the 1.0.0 release!)

Support the collapsible syntax for admonitions allowed by MKDocs