### PR TITLE
Fix Mkdocs Material Admonitions

### DIFF
--- a/mdformat_admon/plugin.py
+++ b/mdformat_admon/plugin.py
@@ -32,7 +32,7 @@ def render_admon(node: RenderTreeNode, context: RenderContext) -> str:
     indent = " " * (min(len(prefix), 3) + 1)
     content = textwrap.indent(separator.join(elements), indent)
 
-    return title_line + "\n" + content if content else title_line
+    return title_line + "\n\n" + content if content else title_line
 
 
 def render_admon_title(


### PR DESCRIPTION
According to the [docs](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#usage) admonitions should look like this:

```
!!! note

    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
    nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
    massa, nec semper lorem quam in massa.
```

However, this plugin formats them without the new line between the title and content:

```
!!! note
    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
    nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
    massa, nec semper lorem quam in massa.
```

Which is not correct.